### PR TITLE
BUG: Fixed handling of inconsistenly placed \r

### DIFF
--- a/src/itkSCIFIOImageIO.cxx.in
+++ b/src/itkSCIFIOImageIO.cxx.in
@@ -143,6 +143,7 @@ std::string SCIFIOImageIO::WaitForNewLines(int pipedatalength)
 {
   char * pipedata;
   std::string readBack;
+  size_t findStart = 0;
   bool keepReading = true;
   std::string errorMessage( "" );
   while( keepReading )
@@ -151,12 +152,16 @@ std::string SCIFIOImageIO::WaitForNewLines(int pipedatalength)
     if( retcode == itksysProcess_Pipe_STDOUT )
       {
       readBack += std::string( pipedata, pipedatalength );
+
+      // Remove any \r so that we only dealing with unix-style line endings
+      size_t backslashRIndex = readBack.find_first_of( '\r', findStart );
+      while ( backslashRIndex != std::string::npos ) {
+        readBack.erase( backslashRIndex );
+        findStart = backslashRIndex;
+      }
+
       // if the two last char are "\n\n", then we're done
-#ifdef WIN32
-      if( readBack.size() >= 4 && readBack.substr( readBack.size()-4, 4 ) == "\r\n\r\n" )
-#else
       if( readBack.size() >= 2 && readBack.substr( readBack.size()-2, 2 ) == "\n\n" )
-#endif
         {
         keepReading = false;
         }
@@ -563,11 +568,7 @@ void SCIFIOImageIO::ReadImageInformation()
     {
 
     // get the key line
-#ifdef WIN32
-    p1 = imgInfo.find("\r\n", p0);
-#else
     p1 = imgInfo.find("\n", p0);
-#endif
 
     line = imgInfo.substr( p0, p1-p0 );
 
@@ -575,44 +576,24 @@ void SCIFIOImageIO::ReadImageInformation()
     if( line == "" )
       {
       // go to the next line
-#ifdef WIN32
-      p0 = p1+2;
-#else
       p0 = p1+1;
-#endif
       continue;
       }
 
     std::string key = line;
     // go to the next line
-#ifdef WIN32
-      p0 = p1+2;
-#else
-      p0 = p1+1;
-#endif
+    p0 = p1+1;
 
     // get the value line
-#ifdef WIN32
-    p1 = imgInfo.find("\r\n", p0);
-#else
     p1 = imgInfo.find("\n", p0);
-#endif
 
     line = imgInfo.substr( p0, p1-p0 );
 
     // ignore the empty lines
-#ifdef WIN32
-    if( line == "\r" )
-#else
     if( line == "" )
-#endif
       {
       // go to the next line
-#ifdef WIN32
-      p0 = p1+2;
-#else
       p0 = p1+1;
-#endif
       continue;
       }
 
@@ -662,11 +643,7 @@ void SCIFIOImageIO::ReadImageInformation()
       }
 
     // go to the next line
-#ifdef WIN32
-      p0 = p1+2;
-#else
-      p0 = p1+1;
-#endif
+    p0 = p1+1;
 
     }
 

--- a/test/itkSCIFIOImageInfoTest.cxx
+++ b/test/itkSCIFIOImageInfoTest.cxx
@@ -168,8 +168,10 @@ int itkSCIFIOImageInfoTest( int argc, char * argv[] )
     }
   for(int i = 0; i < regionDim; i++)
   {
-    std::cout << "\tSpacing " << i + 1 << ": "
-              << imageIO->GetSpacing(i) << std::endl;
+    if ( region.GetSize(i) > 1 ) {
+      std::cout << "\tSpacing " << i + 1 << ": "
+                << imageIO->GetSpacing(i) << std::endl;
+    }
   }
   std::cout << "\tByte Order: "
             << imageIO->GetByteOrderAsString(imageIO->GetByteOrder())


### PR DESCRIPTION
Sometimes on Windows the line endings were \r\n,
sometimes just \n. Rather than debug the inconsistency,
this patch removes \r from strings read from the pipe.
This stops the library from hanging on Windows and makes
all tests to run to completion.

Also fixed a test that was accessing spacing for
dimensions 3, 4, and 5 in a 2D image, which caused
an out-of-bounds read in a vector.
