### PR TITLE
STYLE: Remote modules are non-default modules.

### DIFF
--- a/itk-module.cmake
+++ b/itk-module.cmake
@@ -7,6 +7,7 @@ itk_module(SCIFIO
     ITKIOImageBase
   TEST_DEPENDS
     ITKTestKernel
+  EXCLUDE_FROM_DEFAULT
   DESCRIPTION
     "${DOCUMENTATION}"
 )


### PR DESCRIPTION
All remote modules should have EXCLUDE_FROM_DEFAULT
tag to expose the Module_{} option to the CMake GUI
when configuring ITK build tree with ITK_BUILD_DEFAULT_MODULES
ON.
