### PR TITLE
ENH: Add library specific export specifier.

### DIFF
--- a/include/itkSCIFIOImageIO.h
+++ b/include/itkSCIFIOImageIO.h
@@ -18,6 +18,7 @@
 #ifndef __itkSCIFIOImageIO_h
 #define __itkSCIFIOImageIO_h
 
+#include "SCIFIOExport.h"
 #include "itkStreamingImageIOBase.h"
 
 #include "itksys/Process.h"
@@ -76,7 +77,7 @@ namespace itk
  *
  * \ingroup SCIFIO
  */
-class ITK_EXPORT SCIFIOImageIO : public StreamingImageIOBase
+class SCIFIO_EXPORT SCIFIOImageIO : public StreamingImageIOBase
 {
 public:
   typedef SCIFIOImageIO               Self;

--- a/include/itkSCIFIOImageIOFactory.h
+++ b/include/itkSCIFIOImageIOFactory.h
@@ -18,12 +18,13 @@
 #ifndef __itkSCIFIOImageIOFactory_h
 #define __itkSCIFIOImageIOFactory_h
 
+#include "SCIFIOExport.h"
 #include "itkObjectFactoryBase.h"
 #include "itkImageIOBase.h"
 
 namespace itk
 {
-class ITK_EXPORT SCIFIOImageIOFactory : public ObjectFactoryBase
+class SCIFIO_EXPORT SCIFIOImageIOFactory : public ObjectFactoryBase
 {
 public:
   /** Standard class typedefs **/

--- a/itk-module.cmake
+++ b/itk-module.cmake
@@ -3,6 +3,7 @@ files with the Open Microscopy Envionment (OME) Scientific Imaging Formats
 Input and Output (SCIFIO) library.")
 
 itk_module(SCIFIO
+  ENABLE_SHARED
   DEPENDS
     ITKIOImageBase
   TEST_DEPENDS

--- a/src/itkSCIFIOImageIOFactory.cxx
+++ b/src/itkSCIFIOImageIOFactory.cxx
@@ -53,7 +53,7 @@ SCIFIOImageIOFactory::GetDescription() const
 
 static bool SCIFIOImageIOFactoryHasBeenRegistered;
 
-void SCIFIOImageIOFactoryRegister__Private(void)
+void SCIFIO_EXPORT SCIFIOImageIOFactoryRegister__Private(void)
 {
   if( !SCIFIOImageIOFactoryHasBeenRegistered )
     {


### PR DESCRIPTION
Turn on "ENABLE_SHARED" to make a the compiled library a shared one on
windows, and enable export specification on other platforms.
