### PR TITLE
ENH: Add Wrapping for SCIFIOImageIO.

### DIFF
--- a/wrapping/CMakeLists.txt
+++ b/wrapping/CMakeLists.txt
@@ -1,0 +1,3 @@
+itk_wrap_module(SCIFIO)
+itk_auto_load_submodules()
+itk_end_wrap_module()

--- a/wrapping/itkSCIFIOImageIO.wrap
+++ b/wrapping/itkSCIFIOImageIO.wrap
@@ -1,0 +1,2 @@
+itk_wrap_simple_class("itk::SCIFIOImageIO" POINTER)
+itk_wrap_simple_class("itk::SCIFIOImageIOFactory" POINTER)


### PR DESCRIPTION
This adds SCIFIOImageIO to ITK's wrapping framework.
