### PR TITLE
COMP: Fix installation on OS X

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -11,6 +11,8 @@
 # formats, will no longer work "out of the box" -- the user will instead
 # need to manually add the GPLed Bio-Formats JARs into the mix first.
 #
+# JRE is not downloaded for OS X as JAVA is always installed for this OS.
+#
 set( SCIFIOJars
   http://downloads.openmicroscopy.org/bio-formats/4.4.9/artifacts/loci_tools.jar
   http://jenkins.imagej.net/view/SCIFIO/job/SCIFIOITKBridge/lastSuccessfulBuild/artifact/target/scifio-itk-bridge-1.0.0.jar
@@ -24,7 +26,7 @@ set( JAR_BUILD_TREE_LOCATION
   ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/${jarsDownloadDirectory}/
   )
 set( JAR_INSTALL_TREE_LOCATION
-  ${CMAKE_INSTALL_PREFIX}/${${SCIFIO}_INSTALL_LIBRARY_DIR}/${jarsDownloadDirectory}
+  ${CMAKE_INSTALL_PREFIX}/${SCIFIO_INSTALL_LIBRARY_DIR}/${jarsDownloadDirectory}
   )
 
 # Java Runtime Environment
@@ -33,7 +35,7 @@ set( JRE_BUILD_TREE_LOCATION
   ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/jre
   )
 set( JRE_INSTALL_TREE_LOCATION
-  ${CMAKE_INSTALL_PREFIX}/${${SCIFIO}_INSTALL_LIBRARY_DIR}/jre
+  ${CMAKE_INSTALL_PREFIX}/${SCIFIO_INSTALL_LIBRARY_DIR}/jre
   )
 set( jreTarballMD5 "" )
 if( WIN32 )
@@ -84,17 +86,20 @@ install( DIRECTORY ${JAR_BUILD_TREE_LOCATION}
   FILES_MATCHING PATTERN "*.jar"
   )
 
-configure_file( ${CMAKE_CURRENT_SOURCE_DIR}/DownloadJRE.cmake.in
-  ${CMAKE_CURRENT_BINARY_DIR}/DownloadJRE.cmake
-  @ONLY
-  )
-add_custom_command(TARGET SCIFIO
-  POST_BUILD
-  COMMAND ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_BINARY_DIR}/DownloadJRE.cmake
-  WORKING_DIRECTORY ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}
-  COMMENT "Downloading JRE libraries..."
-  )
-install( DIRECTORY ${JRE_BUILD_TREE_LOCATION}
-  DESTINATION ${JRE_INSTALL_TREE_LOCATION}
-  COMPONENT RuntimeLibraries
-  )
+# Download JRE except for OS X
+IF (NOT APPLE)
+  configure_file( ${CMAKE_CURRENT_SOURCE_DIR}/DownloadJRE.cmake.in
+    ${CMAKE_CURRENT_BINARY_DIR}/DownloadJRE.cmake
+    @ONLY
+    )
+  add_custom_command(TARGET SCIFIO
+    POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_BINARY_DIR}/DownloadJRE.cmake
+    WORKING_DIRECTORY ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}
+    COMMENT "Downloading JRE libraries..."
+    )
+  install( DIRECTORY ${JRE_BUILD_TREE_LOCATION}
+    DESTINATION ${JRE_INSTALL_TREE_LOCATION}
+    COMPONENT RuntimeLibraries
+    )
+endif()


### PR DESCRIPTION
- Do not download JRE for OS X. Java is always installed by default on OS X.
- Fix the download locations, there was a typo in the paths resulting in the files being installed in the wrong folder
