### PR TITLE
BUG: Ensure factory is registered once.

### DIFF
--- a/include/itkSCIFIOImageIOFactory.h
+++ b/include/itkSCIFIOImageIOFactory.h
@@ -47,7 +47,7 @@ public:
   static void RegisterOneFactory(void)
     {
     SCIFIOImageIOFactory::Pointer SCIFIOFactory = SCIFIOImageIOFactory::New();
-    ObjectFactoryBase::RegisterFactory(SCIFIOFactory);
+    ObjectFactoryBase::RegisterFactoryInternal(SCIFIOFactory);
     }
 
 protected:

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -70,7 +70,7 @@ set(SCIFIO_SRC
   ${CMAKE_CURRENT_BINARY_DIR}/itkSCIFIOImageIO.cxx
   )
 
-add_library(SCIFIO ${SCIFIO_SRC})
+add_library(SCIFIO ${ITK_LIBRARY_BUILD_TYPE} ${SCIFIO_SRC})
 target_link_libraries(SCIFIO  ${ITKIOImageBase_LIBRARIES})
 itk_module_target(SCIFIO)
 


### PR DESCRIPTION
This commit updates CMakeLists.txt to ensure built library is shared. It
also uses "RegisterFactoryInternal" to make sure the factory is
registered once into the ImageIOFactory.

See InsightSoftwareConsortium/ITK@39b4ab3 (BUG: Internal factory must
use RegisterFactoryInternal method) for more details.

See ITK issue #3393
https://issues.itk.org/jira/browse/ITK-3393