### PR TITLE
BUG: Verifying that directory exists instead of java executable

### DIFF
--- a/include/itkSCIFIOImageIO.h
+++ b/include/itkSCIFIOImageIO.h
@@ -131,6 +131,7 @@ private:
   std::string FindDimensionOrder(const ImageIORegion & region );
   std::string WaitForNewLines(int pipedatalength);
   void CheckError(std::string message);
+  bool CheckJavaPath(std::string javaHome, std::string &javaCmd);
 
   char ** toCArray( std::vector< std::string > & args )
     {

--- a/src/itkSCIFIOImageIO.cxx.in
+++ b/src/itkSCIFIOImageIO.cxx.in
@@ -29,7 +29,7 @@
 #include <string>
 #include <sstream>
 
-#ifdef WIN32
+#ifdef _WIN32
 #define SCIFIO_SEP ";"
 #include <io.h>
 #include <fcntl.h>
@@ -258,7 +258,7 @@ std::string SCIFIOImageIO::FindDimensionOrder(const ImageIORegion & region)
 bool SCIFIOImageIO::CheckJavaPath(std::string javaHome, std::string &javaCmd)
 {
   std::vector<std::string> javaCmdPath;
-#if defined(WIN32)
+#if defined(_WIN32)
   javaCmd = "javaw.exe" ;
 #else
   javaCmd = "java" ;
@@ -300,7 +300,7 @@ SCIFIOImageIO::SCIFIOImageIO()
   std::string classpath = scifioPath + "bioformats_package.jar" + SCIFIO_SEP + scifioPath + "scifio-itk-bridge.jar";
 
   // determine path to java executable from JAVA_HOME, if available
-#if defined(WIN32)
+#if defined(_WIN32)
   std::string javaCmd = "javaw.exe";
 #else
   std::string javaCmd = "java";
@@ -378,7 +378,7 @@ void SCIFIOImageIO::CreateJavaProcess()
       }
     }
 
-#ifdef WIN32
+#ifdef _WIN32
    SECURITY_ATTRIBUTES saAttr;
    saAttr.nLength = sizeof(SECURITY_ATTRIBUTES);
    saAttr.bInheritHandle = TRUE;
@@ -482,7 +482,7 @@ void SCIFIOImageIO::DestroyJavaProcess()
   itksysProcess_Delete( m_Process );
   m_Process = NULL;
 
-#ifdef WIN32
+#ifdef _WIN32
   CloseHandle( m_Pipe[1] );
 #else
   close( m_Pipe[1] );
@@ -507,7 +507,7 @@ bool SCIFIOImageIO::CanReadFile( const char* FileNameToRead )
   command += "\n";
   itkDebugMacro("SCIFIOImageIO::CanRead command: " << command);
 
-#ifdef WIN32
+#ifdef _WIN32
   DWORD bytesWritten;
   bool r = WriteFile( m_Pipe[1], command.c_str(), command.size(), &bytesWritten, NULL );
 #else
@@ -552,7 +552,7 @@ bool SCIFIOImageIO::SetSeries(int series)
 
   itkDebugMacro("SCIFIOImageIO::SetSeries command: " << command);
 
-#ifdef WIN32
+#ifdef _WIN32
   DWORD bytesWritten;
   WriteFile( m_Pipe[1], command.c_str(), command.size(), &bytesWritten, NULL );
 #else
@@ -601,7 +601,7 @@ int SCIFIOImageIO::GetSeriesCount()
 
   itkDebugMacro("SCIFIOImageIO::GetSeriesCount command: " << command);
 
-#ifdef WIN32
+#ifdef _WIN32
   DWORD bytesWritten;
   WriteFile( m_Pipe[1], command.c_str(), command.size(), &bytesWritten, NULL );
 #else
@@ -647,7 +647,7 @@ void SCIFIOImageIO::ReadImageInformation()
   command += "\n";
   itkDebugMacro("SCIFIOImageIO::ReadImageInformation command: " << command);
 
-#ifdef WIN32
+#ifdef _WIN32
   DWORD bytesWritten;
   WriteFile( m_Pipe[1], command.c_str(), command.size(), &bytesWritten, NULL );
 #else
@@ -870,7 +870,7 @@ void SCIFIOImageIO::Read(void* pData)
   command += "\n";
   itkDebugMacro("SCIFIOImageIO::Read command: " << command);
 
-#ifdef WIN32
+#ifdef _WIN32
   DWORD bytesWritten;
   WriteFile( m_Pipe[1], command.c_str(), command.size(), &bytesWritten, NULL );
 #else
@@ -926,7 +926,7 @@ bool SCIFIOImageIO::CanWriteFile(const char* name)
   command += name;
   command += "\n";
 
-#ifdef WIN32
+#ifdef _WIN32
  DWORD bytesWritten;
   WriteFile( m_Pipe[1], command.c_str(), command.size(), &bytesWritten, NULL );
 #else
@@ -1129,7 +1129,7 @@ void SCIFIOImageIO::Write(const void * buffer )
 
   itkDebugMacro("SCIFIOImageIO::Write command: " << command);
 
-#ifdef WIN32
+#ifdef _WIN32
   DWORD bytesWritten;
   WriteFile( m_Pipe[1], command.c_str(), command.size(), &bytesWritten, NULL );
 #else
@@ -1186,7 +1186,7 @@ void SCIFIOImageIO::Write(const void * buffer )
 
       itkDebugMacro("Writing " << bytesToRead << " bytes to plane " << i << ".  Bytes read: " << bytesRead);
 
-      #ifdef WIN32
+      #ifdef _WIN32
           WriteFile( m_Pipe[1], data, bytesToRead, &bytesWritten, NULL );
       #else
           writtenBytes = write( m_Pipe[1], data, bytesToRead );
@@ -1209,7 +1209,7 @@ void SCIFIOImageIO::Write(const void * buffer )
     std::string planeDone;
 
     // Hand-shake with Java signaling it's OK to send end of plane msg.
-    #ifdef WIN32
+    #ifdef _WIN32
         WriteFile( m_Pipe[1], donemsg, 2, &bytesWritten, NULL );
     #else
         writtenBytes = write( m_Pipe[1], donemsg, 2 );
@@ -1222,7 +1222,7 @@ void SCIFIOImageIO::Write(const void * buffer )
   std::string imageDone;
 
   // Hand-shake with Java signaling it's OK to send end of image msg.
-  #ifdef WIN32
+  #ifdef _WIN32
       WriteFile( m_Pipe[1], donemsg, 2, &bytesWritten, NULL );
   #else
       writtenBytes = write( m_Pipe[1], donemsg, 2 );

--- a/src/itkSCIFIOImageIO.cxx.in
+++ b/src/itkSCIFIOImageIO.cxx.in
@@ -255,6 +255,28 @@ std::string SCIFIOImageIO::FindDimensionOrder(const ImageIORegion & region)
   return command;
 }
 
+bool SCIFIOImageIO::CheckJavaPath(std::string javaHome, std::string &javaCmd)
+{
+  std::vector<std::string> javaCmdPath;
+#if defined(WIN32)
+  javaCmd = "javaw.exe" ;
+#else
+  javaCmd = "java" ;
+#endif
+  javaCmdPath.push_back( "" ); // NB: JoinPath skips the first one (why?).
+  javaCmdPath.push_back( javaHome );
+  javaCmdPath.push_back( "bin" );
+  javaCmdPath.push_back( javaCmd );
+  std::string path = itksys::SystemTools::JoinPath(javaCmdPath);
+  if( itksys::SystemTools::FileExists( path, false ) )
+    {
+    javaCmd = path;
+    return true;
+    }
+  // Else assuming Java is on the path
+  return false;
+}
+
 SCIFIOImageIO::SCIFIOImageIO()
 {
   this->m_FileType = Binary;
@@ -287,10 +309,10 @@ SCIFIOImageIO::SCIFIOImageIO()
   if( javaHome == "" )
     {
     javaHome = "@JRE_BUILD_TREE_LOCATION@";
-    if( !itksys::SystemTools::FileExists( javaHome.c_str(), false ) )
-      {
+    if( !CheckJavaPath(javaHome, javaCmd) )
+    {
       javaHome = "@JRE_INSTALL_TREE_LOCATION@";
-      if( !itksys::SystemTools::FileExists( javaHome.c_str(), false ) )
+      if( !CheckJavaPath( javaHome.c_str(), javaCmd) )
         {
         javaHome = "";
         }
@@ -299,19 +321,6 @@ SCIFIOImageIO::SCIFIOImageIO()
   if( javaHome == "" )
     {
     itkDebugMacro("Warning: JAVA_HOME not set; assuming Java is on the path");
-    }
-  else
-    {
-    std::vector<std::string> javaCmdPath;
-    javaCmdPath.push_back( "" ); // NB: JoinPath skips the first one (why?).
-    javaCmdPath.push_back( javaHome );
-    javaCmdPath.push_back( "bin" );
-#if defined(WIN32)
-    javaCmdPath.push_back( "javaw.exe" );
-#else
-    javaCmdPath.push_back( "java" );
-#endif
-    javaCmd = itksys::SystemTools::JoinPath(javaCmdPath);
     }
 
   // use the appropriate java command


### PR DESCRIPTION
To assess the directory in which the 'java' executable is installed,
SCIFIO was verifying that the given directory existed. However,
in certain cases, the directory existed, but the 'java' executable
did not exist. This could easily happened with the install directory
which by default is set to '/usr/local/' and that is likely to
exist. This would result in SCIFIO trying to use that path
to find the 'java' executable instead of searching in the PATH.
This bug is more easily visible on MacOS as SCIFIO assumes that
java should be installed on the system whereas for Windows and Linux
java is downloaded.