### PR TITLE
BUG: Directory name could not contain spaces

### DIFF
--- a/src/DownloadJRE.cmake.in
+++ b/src/DownloadJRE.cmake.in
@@ -1,19 +1,19 @@
-set( jreTarballDownloadDirectory @jreTarballDownloadDirectory@ )
+set( jreTarballDownloadDirectory "@jreTarballDownloadDirectory@" )
 set( jreTarballMD5 @jreTarballMD5@ )
-set( outputFile ${jreTarballDownloadDirectory}/jre.tar.bz2 )
+set( outputFile "${jreTarballDownloadDirectory}/jre.tar.bz2" )
 
-if( NOT "${jreTarballMD5}" STREQUAL "" AND EXISTS ${outputFile} )
-  file( MD5 ${outputFile} currentMD5 )
+if( NOT "${jreTarballMD5}" STREQUAL "" AND EXISTS "${outputFile}" )
+  file( MD5 "${outputFile}" currentMD5 )
   if( NOT "${jreTarballMD5}" STREQUAL "${currentMD5}" )
-    file( REMOVE ${outputFile} )
+    file( REMOVE "${outputFile}" )
   endif()
 endif()
 
-if( NOT "${jreTarballMD5}" STREQUAL "" AND NOT EXISTS ${outputFile} )
+if( NOT "${jreTarballMD5}" STREQUAL "" AND NOT EXISTS "${outputFile}" )
   file( DOWNLOAD
     "http://midas3.kitware.com/midas/api/rest?method=midas.bitstream.download&checksum=${jreTarballMD5}&name=${outputFile}&algorithm=MD5"
-    ${outputFile}
+    "${outputFile}"
     EXPECTED_HASH MD5=${jreTarballMD5} SHOW_PROGRESS
     )
-  execute_process(COMMAND ${CMAKE_COMMAND} -E tar xjf ${outputFile})
+  execute_process(COMMAND ${CMAKE_COMMAND} -E tar xjf "${outputFile}")
 endif()


### PR DESCRIPTION
If there were spaces in the ITK build directory name,
the configuration would fail.