### PR TITLE
Fix potential index out of bounds

### DIFF
--- a/src/itkSCIFIOImageIO.cxx.in
+++ b/src/itkSCIFIOImageIO.cxx.in
@@ -279,7 +279,7 @@ bool SCIFIOImageIO::CheckJavaPath(std::string javaHome, std::string &javaCmd)
 
 std::string SCIFIOImageIO::RemoveFinalSlash(std::string path) const
 {
-  if(path[path.size()-1] == '/' || path[path.size()-1] == '\\')
+  if(path.size() > 0 && (path[path.size()-1] == '/' || path[path.size()-1] == '\\'))
     {
     path.resize(path.size()-1);
     }

--- a/src/itkSCIFIOImageIO.cxx.in
+++ b/src/itkSCIFIOImageIO.cxx.in
@@ -279,7 +279,7 @@ bool SCIFIOImageIO::CheckJavaPath(std::string javaHome, std::string &javaCmd)
 
 std::string SCIFIOImageIO::RemoveFinalSlash(std::string path) const
 {
-  if(path.size() > 0 && (path[path.size()-1] == '/' || path[path.size()-1] == '\\'))
+  if(!path.empty() && (path[path.size()-1] == '/' || path[path.size()-1] == '\\'))
     {
     path.resize(path.size()-1);
     }


### PR DESCRIPTION
In our application, when compiling ITK with SCIFIO module, this method triggers an "string subscript out of range" assertion (since it's called with empty path, as it's called with JAVA_HOME environment variable's content, which is not set on my machine).

An empty path must not lead to an access to path[-1], this is what this fix addresses.