### PR TITLE
BUG: Ignore input information for ITKRGBSCIFIOImageIOTest

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -37,7 +37,7 @@ itk_add_test( NAME ITKSCIFIOImageIOTest
 
 # Test I/O using itk::RGBPixel
 itk_add_test( NAME ITKRGBSCIFIOImageIOTest
-  COMMAND SCIFIOTestDriver
+  COMMAND SCIFIOTestDriver --ignoreInputInformation
   --compare DATA{Input/image_color.bmp}
                  ${ITK_TEST_OUTPUT_DIR}/image_color_scifio.png
   itkRGBSCIFIOImageIOTest DATA{Input/image_color.bmp}


### PR DESCRIPTION
ITK patch [1] added verification of inconsistent image information including
spacing, origin, and direction. Test ITKRGBSCIFIOImageIOTest now fails
because it compares an input image of type 'bmp' which does not contain
any image spatial information, and an image of type 'png' which does. This
test is not aimed at verifying the image spatial information, so we disable
this verification for this test.

[1] 56b82692f364edcfec82fe308a7f721e2e36ccd7