### PR TITLE
ENH: Require cmake minimum version to be 3.9.5.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.9)
+cmake_minimum_required(VERSION 3.9.5)
 project(SCIFIO)
 
 set(SCIFIO_LIBRARIES SCIFIO)


### PR DESCRIPTION
Require CMake minimum version to be 3.9.5 following ITKv5 requiring
C++11:
https://discourse.itk.org/t/minimum-cmake-version-update/585