### PR TITLE
COMP: Move ITK_DISALLOW_COPY_AND_ASSIGN calls to public section.

### DIFF
--- a/include/itkSCIFIOImageIOFactory.h
+++ b/include/itkSCIFIOImageIOFactory.h
@@ -27,6 +27,8 @@ namespace itk
 class SCIFIO_EXPORT SCIFIOImageIOFactory : public ObjectFactoryBase
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(SCIFIOImageIOFactory);
+
   /** Standard class type alias **/
   using Self = SCIFIOImageIOFactory;
   using Superclass = ObjectFactoryBase;
@@ -53,10 +55,6 @@ public:
 protected:
   SCIFIOImageIOFactory();
   ~SCIFIOImageIOFactory() override;
-
-private:
-  SCIFIOImageIOFactory(const Self&); // purposely not implemented
-  void operator=(const Self&); // purposely not implemented
 };
 } // end namespace itk
 


### PR DESCRIPTION
Move `ITK_DISALLOW_COPY_AND_ASSIGN` calls to public section following
the discussion in
https://discourse.itk.org/t/noncopyable

If legacy (pre-macro) copy and assing methods existed, subsitute them
for the `ITK_DISALLOW_COPY_AND_ASSIGN` macro.