### PR TITLE
COMP: fix direct inclusion of itkExceptionObject

### DIFF
--- a/src/itkSCIFIOImageIO.cxx.in
+++ b/src/itkSCIFIOImageIO.cxx.in
@@ -18,7 +18,6 @@
 
 #include "itkSCIFIOImageIO.h"
 #include "itkIOCommon.h"
-#include "itkExceptionObject.h"
 #include "itkMetaDataObject.h"
 
 #include <cstdio>


### PR DESCRIPTION
Avoids error produced by https://github.com/InsightSoftwareConsortium/ITK/blob/95f095a7f7e366cc2fd7dc87acb4c50a71b85568/Modules/Core/Common/include/itkExceptionObject.h#L19