### PR TITLE
COMP: Avoid getenv with Visual Studio

### DIFF
--- a/src/itkSCIFIOImageIO.cxx.in
+++ b/src/itkSCIFIOImageIO.cxx.in
@@ -19,6 +19,7 @@
 #include "itkSCIFIOImageIO.h"
 #include "itkIOCommon.h"
 #include "itkMetaDataObject.h"
+#include "itksys/SystemTools.hxx"
 
 #include <cstdio>
 #include <cstdlib>
@@ -55,7 +56,7 @@ namespace
 
   std::string getEnv( const char* name )
   {
-    char* result = getenv(name);
+    const char* result = itksys::SystemTools::GetEnv(name);
     if ( result == NULL )
       {
       return "";


### PR DESCRIPTION
To address:

  src\itkSCIFIOImageIO.cxx(58): warning C4996: 'getenv': This function or variable may be unsafe. Consider using _dupenv_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details.