### PR TITLE
STYLE: Convert CMake-language commands to lower case

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -97,7 +97,7 @@ endif()
 unset(jreFileNameBase)
 
 # Download JRE if defined
-IF (DEFINED jreFileName)
+if (DEFINED jreFileName)
 
   ExternalData_Expand_arguments(
     SCIFIO-JRE


### PR DESCRIPTION
Ancient CMake versions required upper-case commands.  Later command names
became case-insensitive.  Now the preferred style is lower-case.