### PR TITLE
ENH: Bump ITK and replace http with https using script

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -4,7 +4,7 @@
 ## See: https://clang.llvm.org/docs/ClangFormatStyleOptions.html for details of each option
 ##
 ## The clang-format binaries can be downloaded as part of the clang binary distributions
-## from http://releases.llvm.org/download.html
+## from https://releases.llvm.org/download.html
 ##
 ## Use the script Utilities/Maintenance/clang-format.bash to faciliate
 ## maintaining a consistent code style.

--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -13,17 +13,17 @@ jobs:
           - os: ubuntu-18.04
             c-compiler: "gcc"
             cxx-compiler: "g++"
-            itk-git-tag: "a89145bccda6a36f42cfdd45d3a6b27234ff54fe"
+            itk-git-tag: "d6acfd26bfcdec606d605beb1301bddfb17c05a6"
             cmake-build-type: "MinSizeRel"
           - os: windows-2019
             c-compiler: "cl.exe"
             cxx-compiler: "cl.exe"
-            itk-git-tag: "a89145bccda6a36f42cfdd45d3a6b27234ff54fe"
+            itk-git-tag: "d6acfd26bfcdec606d605beb1301bddfb17c05a6"
             cmake-build-type: "Release"
           - os: macos-10.15
             c-compiler: "clang"
             cxx-compiler: "clang++"
-            itk-git-tag: "a89145bccda6a36f42cfdd45d3a6b27234ff54fe"
+            itk-git-tag: "d6acfd26bfcdec606d605beb1301bddfb17c05a6"
             cmake-build-type: "MinSizeRel"
 
     steps:
@@ -135,9 +135,9 @@ jobs:
 #    strategy:
 #      max-parallel: 2
 #      matrix:
-#        python-version: [35, 36, 37, 38]
+#        python-version: [37, 38, 39, 310]
 #        include:
-#          - itk-python-git-tag: "v5.1.0.post2"
+#          - itk-python-git-tag: "v5.3rc04"
 #
 #    steps:
 #      - uses: actions/checkout@v2
@@ -173,7 +173,7 @@ jobs:
 #      max-parallel: 2
 #      matrix:
 #        include:
-#          - itk-python-git-tag: "v5.1.0.post2"
+#          - itk-python-git-tag: "v5.3rc04"
 #
 #    steps:
 #      - uses: actions/checkout@v2
@@ -200,9 +200,9 @@ jobs:
 #    strategy:
 #      max-parallel: 2
 #      matrix:
-#        python-version-minor: [5, 6, 7, 8]
+#        python-version-minor: [7, 8, 9, 10]
 #        include:
-#          - itk-python-git-tag: "v5.1.0.post2"
+#          - itk-python-git-tag: "v5.3rc04"
 #
 #    steps:
 #      - uses: actions/checkout@v2
@@ -232,7 +232,7 @@ jobs:
 #        run: |
 #          cd ../../im
 #          call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
-#          set PATH="C:\P\grep;%PATH%"
+#          set PATH=C:\P\grep;%PATH%
 #          set CC=cl.exe
 #          set CXX=cl.exe
 #          C:\Python3${{ matrix.python-version-minor }}-x64\python.exe C:\P\IPP\scripts\windows_build_module_wheels.py --py-envs "3${{ matrix.python-version-minor }}-x64"

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 __NB: This `scifio-imageio` provides the _C++_ side of SCIFIO-ITK integration. For the _Java_ side, see [scifio-itk-bridge](https://github.com/scifio/scifio-itk-bridge).__
 
 This package provides an ImageIO plugin for the
-[Insight Toolkit](http://itk.org/) (ITK) that uses
+[Insight Toolkit](https://itk.org/) (ITK) that uses
 [Bio-Formats](https://github.com/openmicroscopy/bioformats)
 to read and write supported file formats.
 
@@ -28,21 +28,21 @@ The SCIFIO ImageIO plugin was developed by Gaetan Lehmann, Mark Hiner,
 Curtis Rueden, Melissa Linkert and Matt McCormick. Development of this
 module was funded in part by the
 [FARSIGHT project](http://farsight-toolkit.org/), as well as the
-[Open Microscopy Environment](http://openmicroscopy.org/).
+[Open Microscopy Environment](https://openmicroscopy.org/).
 
 Special thanks to Alex Gouaillard, Sebastien Barre, Luis Ibanez and
 Jim Miller for fixes and suggestions.
 
 ## Prerequisites
 
-You should have [CMake](http://www.cmake.org/) installed, to allow the
+You should have [CMake](https://www.cmake.org/) installed, to allow the
 configuration of ITK builds. If you want the latest ITK development build, you
-will need [Git](http://git-scm.com/) as well.
+will need [Git](https://git-scm.com/) as well.
 
 ## Installation
 
 Simply download ITK from the [Kitware software
-page](http://www.itk.org/ITK/resources/software.html). Using CMake, set the
+page](https://www.itk.org/ITK/resources/software.html). Using CMake, set the
 following configuration flag:
 ```
 Module_SCIFIO = ON
@@ -81,10 +81,10 @@ The programs are as follows:
   Reads an input image, and writes it out as a specified type
 * __itkRGBSCIFIOImageTest__:
   Same as itkSCIFIOImageIOTest but for
-  [RGB](http://www.itk.org/Doxygen/html/classitk_1_1RGBPixel.html) types
+  [RGB](https://www.itk.org/Doxygen/html/classitk_1_1RGBPixel.html) types
 * __itkVectorImageSCIFIOImageIOTest__:
   Same as itkSCIFIOImageIOTest but for
-  [VectorImage](http://www.itk.org/Doxygen/html/classitk_1_1VectorImage.html)
+  [VectorImage](https://www.itk.org/Doxygen/html/classitk_1_1VectorImage.html)
   type
 
 For example, to convert a .czi image to a .tif, you would use:
@@ -95,10 +95,10 @@ SCIFIOTestDriver itkSCIFIOImageIOTest in.czi out.tif
 ## Troubleshooting
 
 For general troubleshooting issues using this plugin, please e-mail the
-[SCIFIO mailing list](http://scif.io/mailman/listinfo/scifio).
+[SCIFIO mailing list](https://scif.io/mailman/listinfo/scifio).
 
 Any questions about the capabilities of Bio-Formats can be
-[directed to the OME team](http://www.openmicroscopy.org/site/community).
+[directed to the OME team](https://www.openmicroscopy.org/site/community).
 
 For ITK questions, see the
-[ITK mailing lists](http://www.itk.org/ITK/help/mailing.html).
+[ITK mailing lists](https://www.itk.org/ITK/help/mailing.html).

--- a/include/itkSCIFIOImageIO.h
+++ b/include/itkSCIFIOImageIO.h
@@ -6,7 +6,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,
@@ -71,9 +71,9 @@ namespace itk
  *   size, but also nice for tweaking the VM in many other ways (e.g.,
  *   garbage collection settings).
  *
- * [scifio]:       http://openmicroscopy.org/site/support/bio-formats/developers/scifio.html
- * [bio-formats]:  http://openmicroscopy.org/site/products/bio-formats
- * [file formats]: http://openmicroscopy.org/site/support/bio-formats/formats
+ * [scifio]:       https://openmicroscopy.org/site/support/bio-formats/developers/scifio.html
+ * [bio-formats]:  https://openmicroscopy.org/site/products/bio-formats
+ * [file formats]: https://openmicroscopy.org/site/support/bio-formats/formats
  *
  * \ingroup SCIFIO
  */

--- a/include/itkSCIFIOImageIOFactory.h
+++ b/include/itkSCIFIOImageIOFactory.h
@@ -6,7 +6,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/itkSCIFIOImageIO.cxx.in
+++ b/src/itkSCIFIOImageIO.cxx.in
@@ -6,7 +6,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,
@@ -68,7 +68,7 @@ namespace
    * Splits a string into tokens using the given delimiter.
    *
    * Thanks to SO #236129 for this solution:
-   * http://stackoverflow.com/a/236803
+   * https://stackoverflow.com/a/236803
    */
   std::vector<std::string> &split( const std::string &s, char delim,
                                    std::vector<std::string> &elems )

--- a/src/itkSCIFIOImageIOFactory.cxx
+++ b/src/itkSCIFIOImageIOFactory.cxx
@@ -6,7 +6,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,
@@ -41,7 +41,7 @@ SCIFIOImageIOFactory::GetDescription() const
 {
   return "SCIFIO ImageIO Factory, allows the loading of "
          "SCIFIO-compatible images into Insight; see "
-         "http://openmicroscopy.org/site/support/bio-formats/users/itk";
+         "https://openmicroscopy.org/site/support/bio-formats/users/itk";
 }
 
 // Undocumented API used to register during static initialization.

--- a/test/itkRGBSCIFIOImageIOTest.cxx
+++ b/test/itkRGBSCIFIOImageIOTest.cxx
@@ -6,7 +6,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/itkSCIFIOImageIOTest.cxx
+++ b/test/itkSCIFIOImageIOTest.cxx
@@ -6,7 +6,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/itkSCIFIOImageInfoTest.cxx
+++ b/test/itkSCIFIOImageInfoTest.cxx
@@ -6,7 +6,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,
@@ -51,7 +51,7 @@ namespace
  * Splits a string into tokens using the given delimiter.
  *
  * Thanks to SO #236129 for this solution:
- * http://stackoverflow.com/a/236803
+ * https://stackoverflow.com/a/236803
  */
 std::vector<std::string> &
 split(const std::string & s, char delim, std::vector<std::string> & elems)

--- a/test/itkVectorImageSCIFIOImageIOTest.cxx
+++ b/test/itkVectorImageSCIFIOImageIOTest.cxx
@@ -6,7 +6,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
Automated reformatting with https://github.com/InsightSoftwareConsortium/ITK/blob/master/Utilities/Maintenance/ApplyScriptToRemotes.sh