### PR TITLE
STYLE: Add itkVirtualGetNameOfClassMacro + itkOverrideGetNameOfClassMacro

### DIFF
--- a/include/itkSCIFIOImageIO.h
+++ b/include/itkSCIFIOImageIO.h
@@ -89,7 +89,7 @@ public:
   itkNewMacro(Self);
 
   /** RTTI (and related methods) **/
-  itkTypeMacro(SCIFIOImageIO, Superclass);
+  itkOverrideGetNameOfClassMacro(SCIFIOImageIO);
 
   bool
   SupportsDimension(unsigned long dim) override;

--- a/include/itkSCIFIOImageIOFactory.h
+++ b/include/itkSCIFIOImageIOFactory.h
@@ -45,7 +45,7 @@ public:
   itkFactorylessNewMacro(Self);
 
   /** RTTI (and related methods) **/
-  itkTypeMacro(SCIFIOImageIOFactory, ObjectFactoryBase);
+  itkOverrideGetNameOfClassMacro(SCIFIOImageIOFactory);
 
   /** Register one factory of this type **/
   static void


### PR DESCRIPTION
Added two new macro's, intended to replace the old 'itkTypeMacro' and
'itkTypeMacroNoParent'.

The main aim is to be clearer about what those macro's do: add a virtual
'GetNameOfClass()' member function and override it. Unlike 'itkTypeMacro',
'itkOverrideGetNameOfClassMacro' does not have a 'superclass' parameter, as it
was not used anyway.

Note that originally 'itkTypeMacro' did not use its 'superclass' parameter
either, looking at commit 699b66cb04d410e555656828e8892107add38ccb, Will
Schroeder, June 27, 2001:
https://github.com/InsightSoftwareConsortium/ITK/blob/699b66cb04d410e555656828e8892107add38ccb/Code/Common/itkMacro.h#L331-L337
